### PR TITLE
fix: Close Edge Function auth gaps and document auth matrix

### DIFF
--- a/docs/AUTH_MATRIX.md
+++ b/docs/AUTH_MATRIX.md
@@ -1,0 +1,86 @@
+# Edge Function Auth Matrix
+
+Last updated: 2026-04-21
+
+This document catalogs the authentication model for every Supabase Edge Function. It is a living document — update when functions are added or auth changes.
+
+## How Auth Works in Supabase Edge Functions
+
+- **`verify_jwt = true`** (default): Supabase gateway validates the JWT before the function executes. Requests with an invalid or missing JWT are rejected at the gateway level.
+- **`verify_jwt = false`**: Supabase gateway passes all requests through. The function must implement its own auth (gateway-key, manual JWT check, or intentionally public).
+- **Anon key**: All client requests include the Supabase anon key in the `apikey` header. This is for routing, not security.
+- **SB_GATEWAY_KEY**: A shared secret for internal/cron callers. Enforced inside the function via `X-SB-Gateway-Key` header check.
+
+## Functions with `verify_jwt = false` (explicit in config.toml)
+
+| Function | Auth Mechanism | Caller Type | Rationale |
+|----------|---------------|-------------|-----------|
+| `chart` | Anon key (public) | Client (React, Swift) | Public read-only chart data. Anon key access by design. |
+| `options-chain` | Anon key (public) | Client (React, Swift) | Public read-only options data. Anon key access by design. |
+| `strategies` | Optional Bearer token | Client (React, Swift) | Auth is optional — authenticated users own strategies, anon gets user_id=null. Service-role client used. **Known limitation:** anon RLS allows any caller to mutate any null-user_id row. |
+| `strategy-backtest` | Manual getUser() + 401 | Client (React, Swift) | Performs manual JWT validation inside function (lines 23-28). Returns 401 if no valid user. |
+| `run-backfill-worker` | SB_GATEWAY_KEY | Cron (GH Actions) | Internal worker. Gateway-key enforced (lines 35-57). |
+| `ga-strategy` | SB_GATEWAY_KEY | Cron (automation) | Internal optimization. Gateway-key enforced (added 2026-04-21). No GH Actions workflow currently passes the key — caller must be updated. |
+| `strategy-backtest-worker` | SB_GATEWAY_KEY | Cron (GH Actions) | Internal worker. Gateway-key enforced. |
+| `intraday-live-refresh` | SB_GATEWAY_KEY | Cron (pg_cron) | Internal data refresh. Gateway-key enforced. |
+| `get-unified-validation` | JWT (verify_jwt=true) | Client (Swift) | Changed from false to true on 2026-04-21. Client-facing — APIClient.swift:1240 calls it. |
+
+## Functions with `verify_jwt = true` (Supabase default)
+
+All functions not listed in `supabase/config.toml` default to `verify_jwt = true`. JWT is validated by the Supabase gateway before the function executes.
+
+| Function | Caller Type | Notes |
+|----------|-------------|-------|
+| `adjust-bars-for-splits` | Internal | Data maintenance |
+| `apply-futures-migration` | Internal | One-time migration |
+| `apply-h1-fix` | Internal | One-time fix |
+| `backtest-strategy` | Client | Strategy backtesting |
+| `data-health` | Client | Data quality monitoring |
+| `ensure-coverage` | Internal | Data coverage check |
+| `forecast-quality` | Client | Forecast quality metrics |
+| `futures-chain` | Client | Futures chain data |
+| `futures-continuous` | Client | Continuous futures data |
+| `futures-roots` | Client | Futures root symbols |
+| `get-multi-horizon-forecasts` | Client | ML forecast data |
+| `greeks-surface` | Client | Options Greeks surface |
+| `ingest-live` | Internal | Live data ingestion |
+| `live-trading-executor` | Internal | Live trade execution |
+| `log-validation-audit` | Internal | Validation logging |
+| `market-status` | Client | Market hours/status |
+| `multi-leg-close-leg` | Client | Multi-leg operations |
+| `multi-leg-close-strategy` | Client | Multi-leg operations |
+| `multi-leg-create` | Client | Multi-leg operations |
+| `multi-leg-delete` | Client | Multi-leg operations |
+| `multi-leg-detail` | Client | Multi-leg operations |
+| `multi-leg-evaluate` | Client | Multi-leg operations |
+| `multi-leg-list` | Client | Multi-leg operations |
+| `multi-leg-templates` | Client | Multi-leg operations |
+| `multi-leg-update` | Client | Multi-leg operations |
+| `options-quotes` | Client | Options quote data |
+| `paper-trading-executor` | Client | Paper trade execution |
+| `portfolio-optimize` | Client | Portfolio optimization |
+| `quotes` | Client | Real-time quotes |
+| `seed-futures` | Internal | One-time seed |
+| `stress-test` | Client | Stress test analysis |
+| `symbol-backfill` | Internal | Data backfill |
+| `symbols-search` | Client | Symbol search |
+| `sync-corporate-actions` | Internal | Data sync |
+| `sync-futures-bars` | Internal | Data sync |
+| `sync-futures-data` | Internal | Data sync |
+| `sync-market-calendar` | Internal | Data sync |
+| `technical-indicators` | Client | Technical indicator data |
+| `test-alpaca-futures` | Internal | Test utility |
+| `test-polygon` | Internal | Test utility |
+| `train-model` | Internal | ML model training |
+| `trigger-backfill` | Internal | Backfill trigger |
+| `trigger-ranking-job` | Internal | Ranking job trigger |
+| `ts-strategies` | Client | TradeStation strategies |
+| `user-refresh` | Client | User session refresh |
+| `volatility-surface` | Client | Volatility surface data |
+| `walk-forward-optimize` | Client | Walk-forward optimization |
+
+## Security Notes
+
+- **SB_GATEWAY_KEY** is a single shared secret across all gateway-key-protected functions. Compromise of any caller grants access to all protected functions. Key rotation is not yet implemented — tracked as future work.
+- **Strategies anon RLS gap**: The `user_id IS NULL` RLS policy on `strategy_user_strategies` allows any anon caller to UPDATE/DELETE any null-user_id row. Anon data is intentionally ephemeral. Future fix: add `session_token` column for anon row scoping.
+- **Internal functions with verify_jwt=true**: Functions like `ingest-live`, `train-model`, and `trigger-backfill` use JWT verification. Their callers must send a valid service-role JWT. If called from GitHub Actions, the workflow must use `SUPABASE_SERVICE_ROLE_KEY` as the Bearer token.

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -10,15 +10,16 @@ project_id = "cygflaemtmwiwaviclks"
 verify_jwt = false
 
 # ga-strategy: Triggered by cron automation only, not user-facing.
-# Auth enforced at the job queue level. verify_jwt disabled for performance.
+# Auth enforced inside function via X-SB-Gateway-Key (SB_GATEWAY_KEY).
 [functions.ga-strategy]
 verify_jwt = false
 
 [functions.options-chain]
 verify_jwt = false
 
+# Client-facing. JWT verified by Supabase platform.
 [functions.get-unified-validation]
-verify_jwt = false
+verify_jwt = true
 
 [functions.strategies]
 verify_jwt = false

--- a/supabase/functions/ga-strategy/index.ts
+++ b/supabase/functions/ga-strategy/index.ts
@@ -150,6 +150,31 @@ serve(async (req: Request): Promise<Response> => {
     return handleCorsOptions(origin);
   }
 
+  // Enforce gateway key when verify_jwt is false (only service/cron should call this)
+  const expectedKey = Deno.env.get("SB_GATEWAY_KEY");
+  if (!expectedKey || expectedKey.length === 0) {
+    console.error("[GA Strategy] SB_GATEWAY_KEY is not set");
+    return new Response(
+      JSON.stringify({ error: "Gateway key not configured" }),
+      {
+        status: 503,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }
+  const providedKey = req.headers.get("x-sb-gateway-key") ??
+    req.headers.get("X-SB-Gateway-Key") ?? "";
+  if (providedKey !== expectedKey) {
+    console.warn("[GA Strategy] Invalid or missing X-SB-Gateway-Key");
+    return new Response(
+      JSON.stringify({ error: "Unauthorized" }),
+      {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
+  }
+
   const supabase = getSupabaseClient();
 
   try {

--- a/supabase/functions/ga-strategy/index.ts
+++ b/supabase/functions/ga-strategy/index.ts
@@ -154,25 +154,13 @@ serve(async (req: Request): Promise<Response> => {
   const expectedKey = Deno.env.get("SB_GATEWAY_KEY");
   if (!expectedKey || expectedKey.length === 0) {
     console.error("[GA Strategy] SB_GATEWAY_KEY is not set");
-    return new Response(
-      JSON.stringify({ error: "Gateway key not configured" }),
-      {
-        status: 503,
-        headers: { "Content-Type": "application/json" },
-      },
-    );
+    return errorResponse("Gateway key not configured", 503, origin);
   }
   const providedKey = req.headers.get("x-sb-gateway-key") ??
     req.headers.get("X-SB-Gateway-Key") ?? "";
   if (providedKey !== expectedKey) {
     console.warn("[GA Strategy] Invalid or missing X-SB-Gateway-Key");
-    return new Response(
-      JSON.stringify({ error: "Unauthorized" }),
-      {
-        status: 401,
-        headers: { "Content-Type": "application/json" },
-      },
-    );
+    return errorResponse("Unauthorized", 401, origin);
   }
 
   const supabase = getSupabaseClient();

--- a/supabase/functions/get-unified-validation/index.ts
+++ b/supabase/functions/get-unified-validation/index.ts
@@ -1,4 +1,9 @@
 import { serve } from "https://deno.land/std@0.208.0/http/server.ts";
+import {
+  errorResponse,
+  handleCorsOptions,
+  jsonResponse,
+} from "../_shared/cors.ts";
 import { getSupabaseClient } from "../_shared/supabase-client.ts";
 
 type ValidationType = "backtest" | "walkforward";
@@ -19,22 +24,22 @@ interface ValidationResponse {
 }
 
 serve(async (req: Request) => {
+  const origin = req.headers.get("origin");
+
+  if (req.method === "OPTIONS") {
+    return handleCorsOptions(origin);
+  }
+
   try {
     if (req.method !== "GET") {
-      return new Response(
-        JSON.stringify({ error: "Method not allowed" }),
-        { status: 405, headers: { "Content-Type": "application/json" } },
-      );
+      return errorResponse("Method not allowed", 405, origin);
     }
 
     const url = new URL(req.url);
     const symbolParam = url.searchParams.get("symbol");
 
     if (!symbolParam) {
-      return new Response(
-        JSON.stringify({ error: "symbol parameter required" }),
-        { status: 400, headers: { "Content-Type": "application/json" } },
-      );
+      return errorResponse("symbol parameter required", 400, origin);
     }
 
     const symbol = symbolParam.trim().toUpperCase();
@@ -51,17 +56,11 @@ serve(async (req: Request) => {
         "[get-unified-validation] symbol lookup error",
         symbolError,
       );
-      return new Response(
-        JSON.stringify({ error: "Failed to resolve symbol" }),
-        { status: 500, headers: { "Content-Type": "application/json" } },
-      );
+      return errorResponse("Failed to resolve symbol", 500, origin);
     }
 
     if (!symbolRow) {
-      return new Response(
-        JSON.stringify({ error: `Symbol ${symbol} not found` }),
-        { status: 404, headers: { "Content-Type": "application/json" } },
-      );
+      return errorResponse(`Symbol ${symbol} not found`, 404, origin);
     }
 
     const symbolId = symbolRow.id as string;
@@ -81,10 +80,7 @@ serve(async (req: Request) => {
         "[get-unified-validation] validation stats error",
         validationError,
       );
-      return new Response(
-        JSON.stringify({ error: "Failed to fetch validation stats" }),
-        { status: 500, headers: { "Content-Type": "application/json" } },
-      );
+      return errorResponse("Failed to fetch validation stats", 500, origin);
     }
 
     const validationScores = new Map<ValidationType, number>();
@@ -107,10 +103,7 @@ serve(async (req: Request) => {
 
     if (liveError) {
       console.error("[get-unified-validation] live score error", liveError);
-      return new Response(
-        JSON.stringify({ error: "Failed to fetch live score" }),
-        { status: 500, headers: { "Content-Type": "application/json" } },
-      );
+      return errorResponse("Failed to fetch live score", 500, origin);
     }
 
     const timeframeSignals = new Map<string, string>();
@@ -129,9 +122,10 @@ serve(async (req: Request) => {
           `[get-unified-validation] ${timeframe} signal error`,
           tfError,
         );
-        return new Response(
-          JSON.stringify({ error: "Failed to fetch timeframe signals" }),
-          { status: 500, headers: { "Content-Type": "application/json" } },
+        return errorResponse(
+          "Failed to fetch timeframe signals",
+          500,
+          origin,
         );
       }
 
@@ -159,16 +153,10 @@ serve(async (req: Request) => {
 
     const normalizedResponse = withDefaults(response);
 
-    return new Response(JSON.stringify(normalizedResponse), {
-      status: 200,
-      headers: { "Content-Type": "application/json" },
-    });
+    return jsonResponse(normalizedResponse, 200, req.headers);
   } catch (error) {
     console.error("[get-unified-validation] unexpected error", error);
-    return new Response(
-      JSON.stringify({ error: "Unexpected server error" }),
-      { status: 500, headers: { "Content-Type": "application/json" } },
-    );
+    return errorResponse("Unexpected server error", 500, origin);
   }
 });
 

--- a/supabase/functions/run-backfill-worker/index.ts
+++ b/supabase/functions/run-backfill-worker/index.ts
@@ -8,12 +8,22 @@ import {
   type BackfillBar,
   fetchIntradayForDay,
 } from "../_shared/backfill-adapter.ts";
+import { getCorsHeaders } from "../_shared/cors.ts";
 
-const corsHeaders = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Headers":
-    "authorization, x-client-info, apikey, content-type, x-sb-gateway-key",
-};
+/**
+ * Build CORS headers for this function, merging the shared allowlist-based
+ * headers with the extra `x-sb-gateway-key` header that the backfill worker
+ * requires for gateway-key authentication.
+ */
+function buildCorsHeaders(req: Request): Record<string, string> {
+  const origin = req.headers.get("origin");
+  const shared = getCorsHeaders(origin);
+  // Append x-sb-gateway-key to the shared Allow-Headers value
+  const allowHeaders = shared["Access-Control-Allow-Headers"]
+    ? `${shared["Access-Control-Allow-Headers"]}, x-sb-gateway-key`
+    : "x-sb-gateway-key";
+  return { ...shared, "Access-Control-Allow-Headers": allowHeaders };
+}
 
 interface BackfillChunk {
   id: string;
@@ -26,9 +36,11 @@ interface BackfillChunk {
 }
 
 serve(async (req) => {
+  const corsHeaders = buildCorsHeaders(req);
+
   // Handle CORS preflight
   if (req.method === "OPTIONS") {
-    return new Response("ok", { headers: corsHeaders });
+    return new Response(null, { status: 204, headers: corsHeaders });
   }
 
   // Enforce gateway key when verify_jwt is false (only service/cron should call this)

--- a/supabase/functions/strategies/index.ts
+++ b/supabase/functions/strategies/index.ts
@@ -4,6 +4,18 @@
 // POST /strategies - Create new strategy
 // PUT /strategies - Update strategy
 // DELETE /strategies?id=xxx - Delete strategy
+//
+// AUTH MODEL (documented 2026-04-21):
+// - verify_jwt = false in config.toml (allows anon-key access)
+// - Auth is OPTIONAL: Bearer token extracts user_id; absent token → user_id = null
+// - Uses service-role client (bypasses RLS) — auth scoping is application-level
+// - Anon strategies (user_id IS NULL) are shared/public by design
+//
+// KNOWN LIMITATION: RLS policies (migration 20260222150000) allow ANY anon caller
+// to UPDATE/DELETE ANY row where user_id IS NULL. There is no session or device
+// token to scope anon ownership. Anon strategy data is intentionally ephemeral
+// and unowned — treat as demo/scratch data, not user-owned state.
+// Future improvement: add session_token column for anon row scoping.
 
 import { serve } from "https://deno.land/std@0.208.0/http/server.ts";
 import {


### PR DESCRIPTION
## Summary

- **ga-strategy**: Added SB_GATEWAY_KEY enforcement (was publicly accessible with no auth). Note: no GH Actions workflow currently passes the key — cron caller must be updated.
- **get-unified-validation**: Enabled `verify_jwt=true` and added CORS handling (was publicly accessible with no auth or CORS). Confirmed client-facing via APIClient.swift:1240.
- **run-backfill-worker**: Replaced wildcard CORS (`*`) with shared `getCorsHeaders()` from `_shared/cors.ts`. Preserved `x-sb-gateway-key` in Allow-Headers.
- **strategies**: Documented auth model and known RLS limitation (anon caller can mutate any null-user_id row).
- **AUTH_MATRIX.md**: Created comprehensive auth matrix documenting all 57 Edge Functions' auth models.

## Test plan

- [ ] Deploy ga-strategy — verify unauthenticated curl returns 401
- [ ] Deploy get-unified-validation — verify Swift app still receives validation data (JWT now required)
- [ ] Deploy run-backfill-worker — verify cron job still works (CORS change shouldn't affect server-side callers)
- [ ] Verify React frontend can still call get-unified-validation (CORS headers added)
- [ ] Review AUTH_MATRIX.md for completeness against `supabase/config.toml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)