### PR TITLE
refactor: Consolidate futures functions and add chart cursor pagination

### DIFF
--- a/client-macos/SwiftBoltML/Models/ChartDataV2Response.swift
+++ b/client-macos/SwiftBoltML/Models/ChartDataV2Response.swift
@@ -221,7 +221,7 @@ struct ChartMetadata: Codable, Equatable {
 struct DataQuality: Codable, Equatable {
     let dataAgeHours: Int?
     let isStale: Bool
-    // Legacy fields from chart-data-v2 / chart-read (optional for backward compat)
+    // Optional fields (may be absent in some responses)
     let hasRecentData: Bool?
     let historicalDepthDays: Int?
     // New field from unified /chart endpoint

--- a/client-macos/SwiftBoltML/Services/APIClient.swift
+++ b/client-macos/SwiftBoltML/Services/APIClient.swift
@@ -709,7 +709,6 @@ final class APIClient {
     }
     
     func fetchChartV2(symbol: String, timeframe: String = "d1", days: Int = 60, includeForecast: Bool = true, forecastDays: Int = 10, forecastSteps: Int? = nil) async throws -> ChartDataV2Response {
-        // Redirected from retired chart-data-v2 to the unified chart function.
         // Build URL with cache-buster to bypass CDN caching (for all timeframes)
         var urlComponents = URLComponents(url: functionURL("chart"), resolvingAgainstBaseURL: false)!
         let cacheBuster = Int(Date().timeIntervalSince1970)
@@ -744,7 +743,7 @@ final class APIClient {
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         let bodyData = try JSONSerialization.data(withJSONObject: body)
         request.httpBody = bodyData
-        print("[DEBUG] 📊 chart (was chart-data-v2) request: method=\(request.httpMethod ?? "nil"), bodyBytes=\(bodyData.count)")
+        print("[DEBUG] 📊 chart request: method=\(request.httpMethod ?? "nil"), bodyBytes=\(bodyData.count)")
 
         // Bypass network cache for all requests to ensure fresh data
         request.cachePolicy = .reloadIgnoringLocalCacheData
@@ -758,8 +757,7 @@ final class APIClient {
 
     /// Fetch chart data from the unified GET /chart endpoint.
     ///
-    /// This is the single canonical chart read path — a one-round-trip replacement for the
-    /// three-function fallback chain (chart-data-v2 → chart-read → chart).
+    /// This is the single canonical chart read path (unified chart endpoint).
     ///
     /// - Parameters:
     ///   - symbol: Ticker symbol (e.g. "AAPL", "/ES", "AAPL240119C00150000")

--- a/client-macos/SwiftBoltML/Services/APIClient.swift
+++ b/client-macos/SwiftBoltML/Services/APIClient.swift
@@ -597,10 +597,13 @@ final class APIClient {
     /// - Parameter root: The futures root symbol (e.g., "GC", "ES")
     /// - Returns: Array of futures contracts
     func fetchFuturesChain(root: String) async throws -> [FuturesContract] {
-        guard var components = URLComponents(url: functionURL("futures-chain"), resolvingAgainstBaseURL: false) else {
+        guard var components = URLComponents(url: functionURL("futures"), resolvingAgainstBaseURL: false) else {
             throw APIError.invalidURL
         }
-        components.queryItems = [URLQueryItem(name: "root", value: root)]
+        components.queryItems = [
+            URLQueryItem(name: "type", value: "chain"),
+            URLQueryItem(name: "root", value: root),
+        ]
         
         guard let url = components.url else {
             throw APIError.invalidURL
@@ -667,9 +670,8 @@ final class APIClient {
     }
 
     func fetchChartReadPage(symbol: String, timeframe: String = "d1", before: Int, pageSize: Int = 400) async throws -> ChartResponse {
-        // NOTE: fetchChartReadPage still calls chart-read for pagination; update separately when the
-        // unified chart function gains cursor-based pagination support.
-        var urlComponents = URLComponents(url: functionURL("chart-read"), resolvingAgainstBaseURL: false)!
+        // Migrated from retired chart-read to the unified chart function with cursor pagination.
+        var urlComponents = URLComponents(url: functionURL("chart"), resolvingAgainstBaseURL: false)!
         let cacheBuster = Int(Date().timeIntervalSince1970)
         urlComponents.queryItems = [
             URLQueryItem(name: "t", value: "\(cacheBuster)"),

--- a/supabase/functions/chart/index.ts
+++ b/supabase/functions/chart/index.ts
@@ -522,11 +522,43 @@ serve(async (req: Request): Promise<Response> => {
       ? Math.min(MAX_BAR_LIMIT, Math.max(1, Number(barLimitParam)))
       : MAX_BAR_LIMIT;
 
+    // ── Cursor-based backward pagination ──────────────────────────────────
+    // When `before` is present the caller wants the N most-recent bars
+    // whose timestamp is strictly less than `before`.  `pageSize` controls
+    // how many bars to return (default 400, max 1000).
+    const beforeParam = url.searchParams.get("before");
+    const pageSizeParam = url.searchParams.get("pageSize");
+    const pageSize = pageSizeParam
+      ? Math.min(1000, Math.max(1, Number(pageSizeParam)))
+      : 400;
+
+    // Parse `before` as either a unix-epoch integer (seconds) or ISO 8601.
+    let beforeDate: Date | null = null;
+    if (beforeParam) {
+      const asNum = Number(beforeParam);
+      if (Number.isFinite(asNum) && asNum > 1_000_000_000) {
+        // Treat numbers > 1e9 as unix seconds; smaller values are ambiguous.
+        beforeDate = new Date(
+          asNum > 1e12 ? asNum : asNum * 1000, // auto-detect ms vs s
+        );
+      } else {
+        const parsed = new Date(beforeParam);
+        if (!Number.isNaN(parsed.getTime())) beforeDate = parsed;
+      }
+    }
+    const isCursorMode = beforeDate !== null;
+
     const now = new Date();
     const todayStr = now.toISOString().split("T")[0];
 
-    const endDate = endParam ? new Date(endParam) : now;
-    const startDate = startParam
+    const endDate = isCursorMode
+      ? beforeDate!
+      : endParam
+      ? new Date(endParam)
+      : now;
+    const startDate = isCursorMode
+      ? new Date(0) // fetch as far back as needed; the LIMIT caps the count
+      : startParam
       ? new Date(startParam)
       : new Date(endDate.getTime() - rawDays * 24 * 60 * 60 * 1000);
 
@@ -542,7 +574,9 @@ serve(async (req: Request): Promise<Response> => {
       // futuresMatch[1] = root (e.g. "ES"), futuresMatch[2] = suffix (e.g. "1!" or "H26")
       const futuresRoot = futuresMatch[1].toUpperCase();
       const isContinuousSuffix = /^\d+!$/.test(futuresMatch[2]); // e.g. "1!", "2!"
-      console.log(`[chart] Detected futures symbol: ${symbol} (root=${futuresRoot})`);
+      console.log(
+        `[chart] Detected futures symbol: ${symbol} (root=${futuresRoot})`,
+      );
       try {
         const { data: resolved, error: resolveError } = await supabase.rpc(
           "resolve_futures_symbol",
@@ -651,13 +685,20 @@ serve(async (req: Request): Promise<Response> => {
       // 1. OHLC bars via get_chart_data_v2 RPC (provider-aware)
       // The RPC now accepts p_limit to enforce the cap inside Postgres,
       // bypassing the PostgREST default 1000-row limit on RPC results.
-      supabase.rpc("get_chart_data_v2", {
-        p_symbol_id: symbolId,
-        p_timeframe: timeframe === "w1" ? "d1" : timeframe, // weekly: fetch d1 then aggregate
-        p_start_date: startDate.toISOString(),
-        p_end_date: endDate.toISOString(),
-        p_limit: barLimit,
-      }),
+      // In cursor mode we skip the RPC (it doesn't support strict-less-than
+      // + DESC ordering) and go straight to the fallback path below.
+      isCursorMode
+        ? Promise.resolve({
+          data: null,
+          error: { message: "cursor_mode_skip" },
+        })
+        : supabase.rpc("get_chart_data_v2", {
+          p_symbol_id: symbolId,
+          p_timeframe: timeframe === "w1" ? "d1" : timeframe, // weekly: fetch d1 then aggregate
+          p_start_date: startDate.toISOString(),
+          p_end_date: endDate.toISOString(),
+          p_limit: barLimit,
+        }),
 
       // 2. Options ranks
       includeOptions
@@ -755,19 +796,38 @@ serve(async (req: Request): Promise<Response> => {
     // -------------------------------------------------------------------------
     let barsData: BarRow[] = [];
     if (barsResult.error) {
-      console.error("[chart] Bars RPC error:", barsResult.error);
-      // Fallback: direct table query
-      const { data: fallbackBars } = await supabase
-        .from("ohlc_bars_v2")
-        .select("ts, open, high, low, close, volume, provider, data_status")
-        .eq("symbol_id", symbolId)
-        .eq("timeframe", timeframe === "w1" ? "d1" : timeframe)
-        .eq("is_forecast", false)
-        .gte("ts", startDate.toISOString())
-        .lte("ts", endDate.toISOString())
-        .order("ts", { ascending: true })
-        .limit(MAX_BAR_LIMIT);
-      barsData = (fallbackBars ?? []) as BarRow[];
+      if (!isCursorMode) {
+        console.error("[chart] Bars RPC error:", barsResult.error);
+      }
+      if (isCursorMode) {
+        // Cursor-based backward pagination: fetch `pageSize` bars with ts < before,
+        // ordered DESC so we get the most recent page, then reverse to ascending.
+        const effectiveTf = timeframe === "w1" ? "d1" : timeframe;
+        const { data: cursorBars } = await supabase
+          .from("ohlc_bars_v2")
+          .select("ts, open, high, low, close, volume, provider, data_status")
+          .eq("symbol_id", symbolId)
+          .eq("timeframe", effectiveTf)
+          .eq("is_forecast", false)
+          .lt("ts", beforeDate!.toISOString())
+          .order("ts", { ascending: false })
+          .limit(pageSize);
+        // Reverse to ascending order so response shape is consistent
+        barsData = ((cursorBars ?? []) as BarRow[]).reverse();
+      } else {
+        // Standard fallback: direct table query
+        const { data: fallbackBars } = await supabase
+          .from("ohlc_bars_v2")
+          .select("ts, open, high, low, close, volume, provider, data_status")
+          .eq("symbol_id", symbolId)
+          .eq("timeframe", timeframe === "w1" ? "d1" : timeframe)
+          .eq("is_forecast", false)
+          .gte("ts", startDate.toISOString())
+          .lte("ts", endDate.toISOString())
+          .order("ts", { ascending: true })
+          .limit(MAX_BAR_LIMIT);
+        barsData = (fallbackBars ?? []) as BarRow[];
+      }
     } else {
       barsData = (barsResult.data ?? []) as BarRow[];
     }
@@ -1408,10 +1468,15 @@ serve(async (req: Request): Promise<Response> => {
       dataStatus,
       isMarketOpen,
       totalBars: bars.length,
-      requestedRange: {
-        start: startDate.toISOString(),
-        end: endDate.toISOString(),
-      },
+      requestedRange: isCursorMode
+        ? {
+          start: bars.length > 0 ? bars[0].ts : beforeDate!.toISOString(),
+          end: beforeDate!.toISOString(),
+        }
+        : {
+          start: startDate.toISOString(),
+          end: endDate.toISOString(),
+        },
       latestForecastRunAt,
       hasPendingSplits,
     };

--- a/supabase/functions/futures-chain/index.ts
+++ b/supabase/functions/futures-chain/index.ts
@@ -1,201 +1,24 @@
-// GET /futures/chain?root=GC&asOf=YYYY-MM-DD
-// Returns full contract chain for a futures root with all expiries
+// DEPRECATED: Redirects to consolidated /futures?type=chain endpoint.
+// Remove after monitoring confirms zero redirect hits (1-2 weeks).
 
 import { serve } from "https://deno.land/std@0.208.0/http/server.ts";
-import {
-  corsResponse,
-  getCorsHeaders,
-  handlePreflight,
-} from "../_shared/cors.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { handlePreflight } from "../_shared/cors.ts";
 
-interface FuturesContract {
-  id: string;
-  symbol: string;
-  contract_code: string;
-  expiry_month: number;
-  expiry_year: number;
-  last_trade_date: string | null;
-  first_notice_date: string | null;
-  is_active: boolean;
-  is_spot: boolean;
-  volume_30d: number | null;
-  open_interest: number | null;
-  continuous_alias?: string;
-  continuous_depth?: number;
-}
+serve((req: Request) => {
+  const origin = req.headers.get("Origin");
+  if (req.method === "OPTIONS") return handlePreflight(origin);
 
-interface FuturesChainResponse {
-  success: boolean;
-  root: {
-    symbol: string;
-    name: string;
-    exchange: string;
-    sector: string;
-    tick_size: number;
-    point_value: number;
-  };
-  as_of: string;
-  contracts: FuturesContract[];
-  continuous_aliases: {
-    alias: string;
-    depth: number;
-    contract_symbol: string;
-  }[];
-}
+  const url = new URL(req.url);
+  const params = url.searchParams;
+  params.set("type", "chain");
 
-serve(async (req: Request): Promise<Response> => {
-  const origin = req.headers.get("origin");
+  const base = url.origin.replace("futures-chain", "futures");
+  const redirectUrl = `${url.origin}/functions/v1/futures?${params.toString()}`;
 
-  if (req.method === "OPTIONS") {
-    return handlePreflight(origin);
-  }
+  console.warn(`[DEPRECATED] futures-chain redirect → ${redirectUrl}`);
 
-  if (req.method !== "GET") {
-    return corsResponse({ error: "Method not allowed" }, 405, origin);
-  }
-
-  try {
-    const url = new URL(req.url);
-    const root = url.searchParams.get("root");
-    const asOf = url.searchParams.get("asOf") ||
-      new Date().toISOString().split("T")[0];
-
-    if (!root) {
-      return corsResponse(
-        { error: "Missing required parameter: root" },
-        400,
-        origin,
-      );
-    }
-
-    const supabaseUrl = Deno.env.get("SUPABASE_URL");
-    const supabaseServiceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
-
-    if (!supabaseUrl || !supabaseServiceKey) {
-      console.error("[futures-chain] Missing Supabase credentials");
-      return corsResponse(
-        { error: "Server configuration error" },
-        500,
-        origin,
-      );
-    }
-
-    const supabase = createClient(supabaseUrl, supabaseServiceKey);
-
-    // Get root info
-    const { data: rootData, error: rootError } = await supabase
-      .from("futures_roots")
-      .select("id, symbol, name, exchange, sector, tick_size, point_value")
-      .eq("symbol", root.toUpperCase())
-      .single();
-
-    if (rootError || !rootData) {
-      return corsResponse(
-        { error: `Futures root not found: ${root}` },
-        404,
-        origin,
-      );
-    }
-
-    // Get contracts
-    const { data: contractsData, error: contractsError } = await supabase
-      .from("futures_contracts")
-      .select(`
-        id,
-        symbol,
-        contract_code,
-        expiry_month,
-        expiry_year,
-        last_trade_date,
-        first_notice_date,
-        is_active,
-        is_spot,
-        volume_30d,
-        open_interest,
-        futures_continuous_map!futures_contracts_id_fkey (
-          continuous_alias,
-          depth
-        )
-      `)
-      .eq("root_id", rootData.id)
-      .order("expiry_year", { ascending: true })
-      .order("expiry_month", { ascending: true });
-
-    if (contractsError) {
-      console.error("[futures-chain] Contracts error:", contractsError);
-      return corsResponse(
-        { error: "Database error", details: contractsError.message },
-        500,
-        origin,
-      );
-    }
-
-    // Get continuous mappings
-    const { data: continuousData, error: continuousError } = await supabase
-      .from("futures_continuous_map")
-      .select("continuous_alias, depth, contract_id")
-      .eq("root_id", rootData.id)
-      .eq("is_active", true)
-      .order("depth");
-
-    if (continuousError) {
-      console.error("[futures-chain] Continuous error:", continuousError);
-    }
-
-    // Build continuous aliases list
-    const continuousAliases = (continuousData || []).map((c: any) => ({
-      alias: c.continuous_alias,
-      depth: c.depth,
-      contract_symbol: contractsData?.find((contract: any) =>
-        contract.id === c.contract_id
-      )?.symbol || "",
-    }));
-
-    // Transform contracts
-    const contracts = (contractsData || []).map((c: any) => {
-      const mapping = continuousData?.find((m: any) => m.contract_id === c.id);
-      return {
-        id: c.id,
-        symbol: c.symbol,
-        contract_code: c.contract_code,
-        expiry_month: c.expiry_month,
-        expiry_year: c.expiry_year,
-        last_trade_date: c.last_trade_date,
-        first_notice_date: c.first_notice_date,
-        is_active: c.is_active,
-        is_spot: c.is_spot,
-        volume_30d: c.volume_30d,
-        open_interest: c.open_interest,
-        ...(mapping && {
-          continuous_alias: mapping.continuous_alias,
-          continuous_depth: mapping.depth,
-        }),
-      };
-    });
-
-    const response: FuturesChainResponse = {
-      success: true,
-      root: {
-        symbol: rootData.symbol,
-        name: rootData.name,
-        exchange: rootData.exchange,
-        sector: rootData.sector,
-        tick_size: rootData.tick_size,
-        point_value: rootData.point_value,
-      },
-      as_of: asOf,
-      contracts,
-      continuous_aliases: continuousAliases,
-    };
-
-    return corsResponse(response, 200, origin);
-  } catch (error) {
-    console.error("[futures-chain] Error:", error);
-    return corsResponse(
-      { error: "Internal server error" },
-      500,
-      origin,
-    );
-  }
+  return new Response(null, {
+    status: 301,
+    headers: { Location: redirectUrl },
+  });
 });

--- a/supabase/functions/futures-continuous/index.ts
+++ b/supabase/functions/futures-continuous/index.ts
@@ -1,186 +1,23 @@
-// GET /futures/continuous?root=GC&depth=1
-// Returns continuous contract mapping (e.g., GC1!, GC2!) for a root
+// DEPRECATED: Redirects to consolidated /futures?type=continuous endpoint.
+// Remove after monitoring confirms zero redirect hits (1-2 weeks).
 
 import { serve } from "https://deno.land/std@0.208.0/http/server.ts";
-import {
-  corsResponse,
-  getCorsHeaders,
-  handlePreflight,
-} from "../_shared/cors.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { handlePreflight } from "../_shared/cors.ts";
 
-interface ContinuousContract {
-  alias: string;
-  depth: number;
-  contract: {
-    id: string;
-    symbol: string;
-    expiry_month: number;
-    expiry_year: number;
-    last_trade_date: string | null;
-    days_to_expiry: number;
-  };
-  valid_from: string;
-  valid_until: string | null;
-}
+serve((req: Request) => {
+  const origin = req.headers.get("Origin");
+  if (req.method === "OPTIONS") return handlePreflight(origin);
 
-interface FuturesContinuousResponse {
-  success: boolean;
-  root: string;
-  depth: number;
-  as_of: string;
-  contracts: ContinuousContract[];
-}
+  const url = new URL(req.url);
+  const params = url.searchParams;
+  params.set("type", "continuous");
 
-serve(async (req: Request): Promise<Response> => {
-  const origin = req.headers.get("origin");
+  const redirectUrl = `${url.origin}/functions/v1/futures?${params.toString()}`;
 
-  if (req.method === "OPTIONS") {
-    return handlePreflight(origin);
-  }
+  console.warn(`[DEPRECATED] futures-continuous redirect → ${redirectUrl}`);
 
-  if (req.method !== "GET") {
-    return corsResponse({ error: "Method not allowed" }, 405, origin);
-  }
-
-  try {
-    const url = new URL(req.url);
-    const root = url.searchParams.get("root");
-    const depthParam = url.searchParams.get("depth");
-    const asOf = url.searchParams.get("asOf") ||
-      new Date().toISOString().split("T")[0];
-
-    if (!root) {
-      return corsResponse(
-        { error: "Missing required parameter: root" },
-        400,
-        origin,
-      );
-    }
-
-    const depth = depthParam ? parseInt(depthParam, 10) : undefined;
-    if (depthParam && (isNaN(depth!) || depth! < 1 || depth! > 12)) {
-      return corsResponse(
-        { error: "Invalid depth parameter. Must be between 1 and 12" },
-        400,
-        origin,
-      );
-    }
-
-    const supabaseUrl = Deno.env.get("SUPABASE_URL");
-    const supabaseServiceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
-
-    if (!supabaseUrl || !supabaseServiceKey) {
-      console.error("[futures-continuous] Missing Supabase credentials");
-      return corsResponse(
-        { error: "Server configuration error" },
-        500,
-        origin,
-      );
-    }
-
-    const supabase = createClient(supabaseUrl, supabaseServiceKey);
-
-    // Get root info
-    const { data: rootData, error: rootError } = await supabase
-      .from("futures_roots")
-      .select("id, symbol")
-      .eq("symbol", root.toUpperCase())
-      .single();
-
-    if (rootError || !rootData) {
-      return corsResponse(
-        { error: `Futures root not found: ${root}` },
-        404,
-        origin,
-      );
-    }
-
-    // Build query for continuous mappings
-    let query = supabase
-      .from("futures_continuous_map")
-      .select(`
-        continuous_alias,
-        depth,
-        valid_from,
-        valid_until,
-        futures_contracts!futures_continuous_map_contract_id_fkey (
-          id,
-          symbol,
-          expiry_month,
-          expiry_year,
-          last_trade_date
-        )
-      `)
-      .eq("root_id", rootData.id)
-      .lte("valid_from", asOf)
-      .or(`valid_until.is.null,valid_until.gte.${asOf}`)
-      .order("depth");
-
-    if (depth) {
-      query = query.eq("depth", depth);
-    }
-
-    const { data, error } = await query;
-
-    if (error) {
-      console.error("[futures-continuous] Database error:", error);
-      return corsResponse(
-        { error: "Database error", details: error.message },
-        500,
-        origin,
-      );
-    }
-
-    if (!data || data.length === 0) {
-      return corsResponse(
-        { error: `No continuous contracts found for ${root}` },
-        404,
-        origin,
-      );
-    }
-
-    // Transform response
-    const contracts: ContinuousContract[] = data.map((row: any) => {
-      const contract = row.futures_contracts;
-      const daysToExpiry = contract.last_trade_date
-        ? Math.ceil(
-          (new Date(contract.last_trade_date).getTime() -
-            new Date(asOf).getTime()) / (1000 * 60 * 60 * 24),
-        )
-        : 0;
-
-      return {
-        alias: row.continuous_alias,
-        depth: row.depth,
-        contract: {
-          id: contract.id,
-          symbol: contract.symbol,
-          expiry_month: contract.expiry_month,
-          expiry_year: contract.expiry_year,
-          last_trade_date: contract.last_trade_date,
-          days_to_expiry: daysToExpiry,
-        },
-        valid_from: row.valid_from,
-        valid_until: row.valid_until,
-      };
-    });
-
-    const response: FuturesContinuousResponse = {
-      success: true,
-      root: rootData.symbol,
-      depth: depth || contracts.length,
-      as_of: asOf,
-      contracts,
-    };
-
-    return corsResponse(response, 200, origin);
-  } catch (error) {
-    console.error("[futures-continuous] Error:", error);
-    return corsResponse(
-      { error: "Internal server error" },
-      500,
-      origin,
-    );
-  }
+  return new Response(null, {
+    status: 301,
+    headers: { Location: redirectUrl },
+  });
 });

--- a/supabase/functions/futures-roots/index.ts
+++ b/supabase/functions/futures-roots/index.ts
@@ -1,100 +1,23 @@
-// GET /futures/roots?sector=indices|metals
-// Returns list of futures roots (ES, NQ, GC, etc.) with metadata
+// DEPRECATED: Redirects to consolidated /futures?type=roots endpoint.
+// Remove after monitoring confirms zero redirect hits (1-2 weeks).
 
 import { serve } from "https://deno.land/std@0.208.0/http/server.ts";
-import {
-  corsResponse,
-  getCorsHeaders,
-  handlePreflight,
-} from "../_shared/cors.ts";
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { handlePreflight } from "../_shared/cors.ts";
 
-interface FuturesRoot {
-  id: string;
-  symbol: string;
-  name: string;
-  exchange: string;
-  sector: string;
-  tick_size: number;
-  point_value: number;
-  currency: string;
-  session_template?: string;
-}
+serve((req: Request) => {
+  const origin = req.headers.get("Origin");
+  if (req.method === "OPTIONS") return handlePreflight(origin);
 
-interface FuturesRootsResponse {
-  success: boolean;
-  count: number;
-  sector?: string;
-  roots: FuturesRoot[];
-}
+  const url = new URL(req.url);
+  const params = url.searchParams;
+  params.set("type", "roots");
 
-serve(async (req: Request): Promise<Response> => {
-  const origin = req.headers.get("origin");
+  const redirectUrl = `${url.origin}/functions/v1/futures?${params.toString()}`;
 
-  if (req.method === "OPTIONS") {
-    return handlePreflight(origin);
-  }
+  console.warn(`[DEPRECATED] futures-roots redirect → ${redirectUrl}`);
 
-  if (req.method !== "GET") {
-    return corsResponse({ error: "Method not allowed" }, 405, origin);
-  }
-
-  try {
-    const url = new URL(req.url);
-    const sector = url.searchParams.get("sector") || undefined;
-
-    // Initialize Supabase client
-    const supabaseUrl = Deno.env.get("SUPABASE_URL");
-    const supabaseServiceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY");
-
-    if (!supabaseUrl || !supabaseServiceKey) {
-      console.error("[futures-roots] Missing Supabase credentials");
-      return corsResponse(
-        { error: "Server configuration error" },
-        500,
-        origin,
-      );
-    }
-
-    const supabase = createClient(supabaseUrl, supabaseServiceKey);
-
-    // Build query
-    let query = supabase
-      .from("futures_roots")
-      .select(
-        "id, symbol, name, exchange, sector, tick_size, point_value, currency, session_template",
-      )
-      .order("symbol");
-
-    if (sector) {
-      query = query.eq("sector", sector);
-    }
-
-    const { data, error } = await query;
-
-    if (error) {
-      console.error("[futures-roots] Database error:", error);
-      return corsResponse(
-        { error: "Database error", details: error.message },
-        500,
-        origin,
-      );
-    }
-
-    const response: FuturesRootsResponse = {
-      success: true,
-      count: data?.length || 0,
-      ...(sector && { sector }),
-      roots: data || [],
-    };
-
-    return corsResponse(response, 200, origin);
-  } catch (error) {
-    console.error("[futures-roots] Error:", error);
-    return corsResponse(
-      { error: "Internal server error" },
-      500,
-      origin,
-    );
-  }
+  return new Response(null, {
+    status: 301,
+    headers: { Location: redirectUrl },
+  });
 });

--- a/supabase/functions/futures/index.ts
+++ b/supabase/functions/futures/index.ts
@@ -1,0 +1,459 @@
+// GET /futures?type=roots|chain|continuous
+// Consolidated futures endpoint merging futures-roots, futures-chain, and futures-continuous.
+//
+// Auto-detection when `type` is omitted:
+//   - `sector` param present  -> roots
+//   - `asOf` param present    -> chain
+//   - `depth` param present   -> continuous
+//   - none of the above       -> 400 with usage hint
+
+import { serve } from "https://deno.land/std@0.208.0/http/server.ts";
+import {
+  corsResponse,
+  handlePreflight,
+} from "../_shared/cors.ts";
+import { getSupabaseClient } from "../_shared/supabase-client.ts";
+
+// ─── Shared types ──────────────────────────────────────────────────────────
+
+interface FuturesContract {
+  id: string;
+  symbol: string;
+  contract_code: string;
+  expiry_month: number;
+  expiry_year: number;
+  last_trade_date: string | null;
+  first_notice_date: string | null;
+  is_active: boolean;
+  is_spot: boolean;
+  volume_30d: number | null;
+  open_interest: number | null;
+  continuous_alias?: string;
+  continuous_depth?: number;
+}
+
+interface FuturesChainResponse {
+  success: boolean;
+  root: {
+    symbol: string;
+    name: string;
+    exchange: string;
+    sector: string;
+    tick_size: number;
+    point_value: number;
+  };
+  as_of: string;
+  contracts: FuturesContract[];
+  continuous_aliases: {
+    alias: string;
+    depth: number;
+    contract_symbol: string;
+  }[];
+}
+
+interface ContinuousContract {
+  alias: string;
+  depth: number;
+  contract: {
+    id: string;
+    symbol: string;
+    expiry_month: number;
+    expiry_year: number;
+    last_trade_date: string | null;
+    days_to_expiry: number;
+  };
+  valid_from: string;
+  valid_until: string | null;
+}
+
+interface FuturesContinuousResponse {
+  success: boolean;
+  root: string;
+  depth: number;
+  as_of: string;
+  contracts: ContinuousContract[];
+}
+
+interface FuturesRoot {
+  id: string;
+  symbol: string;
+  name: string;
+  exchange: string;
+  sector: string;
+  tick_size: number;
+  point_value: number;
+  currency: string;
+  session_template?: string;
+}
+
+interface FuturesRootsResponse {
+  success: boolean;
+  count: number;
+  sector?: string;
+  roots: FuturesRoot[];
+}
+
+// ─── Type detection ────────────────────────────────────────────────────────
+
+type FuturesType = "roots" | "chain" | "continuous";
+
+function detectType(url: URL): FuturesType | null {
+  const explicit = url.searchParams.get("type");
+  if (explicit) {
+    const lower = explicit.toLowerCase();
+    if (lower === "roots" || lower === "chain" || lower === "continuous") {
+      return lower;
+    }
+    return null; // invalid explicit type
+  }
+
+  // Auto-detect based on distinguishing params
+  if (url.searchParams.has("sector")) return "roots";
+  if (url.searchParams.has("asOf")) return "chain";
+  if (url.searchParams.has("depth")) return "continuous";
+
+  // If `root` param is present but no distinguishing param, default to chain
+  if (url.searchParams.has("root")) return "chain";
+
+  // No params at all -> list roots
+  return "roots";
+}
+
+// ─── Handlers ──────────────────────────────────────────────────────────────
+
+async function handleRoots(
+  url: URL,
+  origin: string | null,
+): Promise<Response> {
+  const sector = url.searchParams.get("sector") || undefined;
+
+  const supabase = getSupabaseClient();
+
+  let query = supabase
+    .from("futures_roots")
+    .select(
+      "id, symbol, name, exchange, sector, tick_size, point_value, currency, session_template",
+    )
+    .order("symbol");
+
+  if (sector) {
+    query = query.eq("sector", sector);
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    console.error("[futures] roots database error:", error);
+    return corsResponse(
+      { error: "Database error", details: error.message },
+      500,
+      origin,
+    );
+  }
+
+  const response: FuturesRootsResponse = {
+    success: true,
+    count: data?.length || 0,
+    ...(sector && { sector }),
+    roots: data || [],
+  };
+
+  return corsResponse(response, 200, origin);
+}
+
+async function handleChain(
+  url: URL,
+  origin: string | null,
+): Promise<Response> {
+  const root = url.searchParams.get("root");
+  const asOf = url.searchParams.get("asOf") ||
+    new Date().toISOString().split("T")[0];
+
+  if (!root) {
+    return corsResponse(
+      { error: "Missing required parameter: root" },
+      400,
+      origin,
+    );
+  }
+
+  const supabase = getSupabaseClient();
+
+  // Get root info
+  const { data: rootData, error: rootError } = await supabase
+    .from("futures_roots")
+    .select("id, symbol, name, exchange, sector, tick_size, point_value")
+    .eq("symbol", root.toUpperCase())
+    .single();
+
+  if (rootError || !rootData) {
+    return corsResponse(
+      { error: `Futures root not found: ${root}` },
+      404,
+      origin,
+    );
+  }
+
+  // Get contracts
+  const { data: contractsData, error: contractsError } = await supabase
+    .from("futures_contracts")
+    .select(`
+      id,
+      symbol,
+      contract_code,
+      expiry_month,
+      expiry_year,
+      last_trade_date,
+      first_notice_date,
+      is_active,
+      is_spot,
+      volume_30d,
+      open_interest,
+      futures_continuous_map!futures_contracts_id_fkey (
+        continuous_alias,
+        depth
+      )
+    `)
+    .eq("root_id", rootData.id)
+    .order("expiry_year", { ascending: true })
+    .order("expiry_month", { ascending: true });
+
+  if (contractsError) {
+    console.error("[futures] chain contracts error:", contractsError);
+    return corsResponse(
+      { error: "Database error", details: contractsError.message },
+      500,
+      origin,
+    );
+  }
+
+  // Get continuous mappings
+  const { data: continuousData, error: continuousError } = await supabase
+    .from("futures_continuous_map")
+    .select("continuous_alias, depth, contract_id")
+    .eq("root_id", rootData.id)
+    .eq("is_active", true)
+    .order("depth");
+
+  if (continuousError) {
+    console.error("[futures] chain continuous error:", continuousError);
+  }
+
+  // Build continuous aliases list
+  const continuousAliases = (continuousData || []).map((c: any) => ({
+    alias: c.continuous_alias,
+    depth: c.depth,
+    contract_symbol: contractsData?.find((contract: any) =>
+      contract.id === c.contract_id
+    )?.symbol || "",
+  }));
+
+  // Transform contracts
+  const contracts = (contractsData || []).map((c: any) => {
+    const mapping = continuousData?.find((m: any) => m.contract_id === c.id);
+    return {
+      id: c.id,
+      symbol: c.symbol,
+      contract_code: c.contract_code,
+      expiry_month: c.expiry_month,
+      expiry_year: c.expiry_year,
+      last_trade_date: c.last_trade_date,
+      first_notice_date: c.first_notice_date,
+      is_active: c.is_active,
+      is_spot: c.is_spot,
+      volume_30d: c.volume_30d,
+      open_interest: c.open_interest,
+      ...(mapping && {
+        continuous_alias: mapping.continuous_alias,
+        continuous_depth: mapping.depth,
+      }),
+    };
+  });
+
+  const response: FuturesChainResponse = {
+    success: true,
+    root: {
+      symbol: rootData.symbol,
+      name: rootData.name,
+      exchange: rootData.exchange,
+      sector: rootData.sector,
+      tick_size: rootData.tick_size,
+      point_value: rootData.point_value,
+    },
+    as_of: asOf,
+    contracts,
+    continuous_aliases: continuousAliases,
+  };
+
+  return corsResponse(response, 200, origin);
+}
+
+async function handleContinuous(
+  url: URL,
+  origin: string | null,
+): Promise<Response> {
+  const root = url.searchParams.get("root");
+  const depthParam = url.searchParams.get("depth");
+  const asOf = url.searchParams.get("asOf") ||
+    new Date().toISOString().split("T")[0];
+
+  if (!root) {
+    return corsResponse(
+      { error: "Missing required parameter: root" },
+      400,
+      origin,
+    );
+  }
+
+  const depth = depthParam ? parseInt(depthParam, 10) : undefined;
+  if (depthParam && (isNaN(depth!) || depth! < 1 || depth! > 12)) {
+    return corsResponse(
+      { error: "Invalid depth parameter. Must be between 1 and 12" },
+      400,
+      origin,
+    );
+  }
+
+  const supabase = getSupabaseClient();
+
+  // Get root info
+  const { data: rootData, error: rootError } = await supabase
+    .from("futures_roots")
+    .select("id, symbol")
+    .eq("symbol", root.toUpperCase())
+    .single();
+
+  if (rootError || !rootData) {
+    return corsResponse(
+      { error: `Futures root not found: ${root}` },
+      404,
+      origin,
+    );
+  }
+
+  // Build query for continuous mappings
+  let query = supabase
+    .from("futures_continuous_map")
+    .select(`
+      continuous_alias,
+      depth,
+      valid_from,
+      valid_until,
+      futures_contracts!futures_continuous_map_contract_id_fkey (
+        id,
+        symbol,
+        expiry_month,
+        expiry_year,
+        last_trade_date
+      )
+    `)
+    .eq("root_id", rootData.id)
+    .lte("valid_from", asOf)
+    .or(`valid_until.is.null,valid_until.gte.${asOf}`)
+    .order("depth");
+
+  if (depth) {
+    query = query.eq("depth", depth);
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    console.error("[futures] continuous database error:", error);
+    return corsResponse(
+      { error: "Database error", details: error.message },
+      500,
+      origin,
+    );
+  }
+
+  if (!data || data.length === 0) {
+    return corsResponse(
+      { error: `No continuous contracts found for ${root}` },
+      404,
+      origin,
+    );
+  }
+
+  // Transform response
+  const contracts: ContinuousContract[] = data.map((row: any) => {
+    const contract = row.futures_contracts;
+    const daysToExpiry = contract.last_trade_date
+      ? Math.ceil(
+        (new Date(contract.last_trade_date).getTime() -
+          new Date(asOf).getTime()) / (1000 * 60 * 60 * 24),
+      )
+      : 0;
+
+    return {
+      alias: row.continuous_alias,
+      depth: row.depth,
+      contract: {
+        id: contract.id,
+        symbol: contract.symbol,
+        expiry_month: contract.expiry_month,
+        expiry_year: contract.expiry_year,
+        last_trade_date: contract.last_trade_date,
+        days_to_expiry: daysToExpiry,
+      },
+      valid_from: row.valid_from,
+      valid_until: row.valid_until,
+    };
+  });
+
+  const response: FuturesContinuousResponse = {
+    success: true,
+    root: rootData.symbol,
+    depth: depth || contracts.length,
+    as_of: asOf,
+    contracts,
+  };
+
+  return corsResponse(response, 200, origin);
+}
+
+// ─── Main handler ──────────────────────────────────────────────────────────
+
+serve(async (req: Request): Promise<Response> => {
+  const origin = req.headers.get("origin");
+
+  if (req.method === "OPTIONS") {
+    return handlePreflight(origin);
+  }
+
+  if (req.method !== "GET") {
+    return corsResponse({ error: "Method not allowed" }, 405, origin);
+  }
+
+  try {
+    const url = new URL(req.url);
+    const type = detectType(url);
+
+    if (!type) {
+      return corsResponse(
+        {
+          error:
+            "Invalid or undetectable type. Use ?type=roots|chain|continuous, or provide distinguishing params (sector, asOf, depth, root).",
+        },
+        400,
+        origin,
+      );
+    }
+
+    switch (type) {
+      case "roots":
+        return await handleRoots(url, origin);
+      case "chain":
+        return await handleChain(url, origin);
+      case "continuous":
+        return await handleContinuous(url, origin);
+    }
+  } catch (error) {
+    console.error("[futures] Error:", error);
+    return corsResponse(
+      { error: "Internal server error" },
+      500,
+      origin,
+    );
+  }
+});


### PR DESCRIPTION
## Summary

- **Consolidated futures function:** Merged futures-chain, futures-continuous, futures-roots into single `futures/` function with `?type=chain|continuous|roots` query-param routing + auto-detection from existing params
- **Chart cursor pagination:** Added `before` (timestamp) and `pageSize` params to the chart endpoint for backward pagination, enabling migration from the deleted `chart-read` function
- **Swift caller migration:** Updated `fetchFuturesChain()` → `futures?type=chain` and `fetchChartReadPage()` → `chart` with before/pageSize params. Zero references to `chart-read` or `futures-chain` remain
- **Redirect stubs:** Old futures-chain/continuous/roots functions replaced with lightweight 301 redirects that log deprecation warnings
- **chart-data-v2 cleanup:** Removed legacy endpoint name references from Swift client comments

## Test plan

- [ ] `GET /futures?type=chain&root=GC` returns chain data
- [ ] `GET /futures?type=roots&sector=indices` returns roots list
- [ ] `GET /futures?root=GC` (no type param) auto-detects chain
- [ ] `GET /futures-chain?root=GC` → 301 redirect to `/futures?type=chain&root=GC`
- [ ] `GET /chart?symbol=AAPL&timeframe=d1&before=1714000000&pageSize=100` returns paginated bars
- [ ] Existing `GET /chart?symbol=AAPL&timeframe=d1&days=180` unchanged
- [ ] Swift app: futures chain loads, historical chart scrolling works
- [ ] Zero references to `chart-read` in codebase (grep confirms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)