### PR TITLE
fix(ml): Eliminate temporal integrity violations in forecast pipeline

### DIFF
--- a/ml/src/evaluation/purged_walk_forward_cv.py
+++ b/ml/src/evaluation/purged_walk_forward_cv.py
@@ -75,10 +75,8 @@ class PurgedWalkForwardCV:
             embargo_start = test_end
             embargo_end = min(embargo_start + self.embargo_days, n_samples)
 
-            # Training indices: before test + after embargo
-            train_indices = np.concatenate(
-                [np.arange(0, test_start), np.arange(embargo_end, n_samples)]
-            )
+            # Training indices: only data BEFORE the test fold (no future data)
+            train_indices = np.arange(0, test_start)
 
             # Test indices
             test_indices = np.arange(test_start, test_end)

--- a/ml/src/models/lstm_forecaster.py
+++ b/ml/src/models/lstm_forecaster.py
@@ -210,9 +210,11 @@ class LSTMForecaster:
         logger.info("Training LSTM model...")
 
         try:
-            # Scale data
+            # Scale data — fit scaler on TRAIN slice only to prevent leakage
             prices = df["close"].values.reshape(-1, 1)
-            scaled_data = self.scaler.fit_transform(prices).flatten()
+            train_size = int(len(prices) * (1 - validation_split))
+            self.scaler.fit(prices[:train_size])
+            scaled_data = self.scaler.transform(prices).flatten()
 
             # Prepare sequences
             X, y = self._prepare_sequences(scaled_data)

--- a/ml/src/models/xgboost_forecaster.py
+++ b/ml/src/models/xgboost_forecaster.py
@@ -10,7 +10,6 @@ from typing import Any, Optional
 
 import numpy as np
 import pandas as pd
-from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import RobustScaler
 from xgboost import XGBClassifier
 
@@ -158,14 +157,11 @@ class XGBoostForecaster:
         X_scaled = self.scaler.fit_transform(X_num)
         y_arr = np.asarray(y).ravel()
         y_bin = np.where(np.asarray(y_arr) == "bullish", 1, 0)
-        # Split for early stopping (80% train, 20% val), stratified for balance
-        X_tr, X_es, y_tr, y_es = train_test_split(
-            X_scaled,
-            y_bin,
-            test_size=0.2,
-            stratify=y_bin,
-            random_state=42,
-        )
+        # Temporal split for early stopping (80% train, 20% val) — no shuffle
+        split_idx = int(len(X_scaled) * 0.8)
+        split_idx = max(1, min(split_idx, len(X_scaled) - 1))  # ensure non-empty splits
+        X_tr, X_es = X_scaled[:split_idx], X_scaled[split_idx:]
+        y_tr, y_es = y_bin[:split_idx], y_bin[split_idx:]
         logger.info("Training XGBoost with early stopping...")
         self.model.fit(
             X_tr,

--- a/ml/src/unified_forecast_job.py
+++ b/ml/src/unified_forecast_job.py
@@ -702,11 +702,11 @@ class UnifiedForecastProcessor:
                             base_return = (model_target - current_price_value) / current_price_value
                         base_return = float(base_return or 0.0)
 
-                        horizon_days = self._horizon_to_days(horizon_key)
-                        horizon_weight = min(horizon_days / 20.0, 1.0)
+                        h_days_synthesis = self._horizon_to_days(horizon_key)
+                        horizon_weight = min(h_days_synthesis / 20.0, 1.0)
 
                         # Multi-timeframe consensus adjustment
-                        dominant_tf, secondary_tf = self._dominant_timeframes(horizon_days)
+                        dominant_tf, secondary_tf = self._dominant_timeframes(h_days_synthesis)
                         dominant_signal = mtf_signals.get(dominant_tf, {})
                         dominant_trend = dominant_signal.get("supertrend_trend")
                         if dominant_trend is None:


### PR DESCRIPTION
Fixes XGBoost shuffle split, walk-forward CV future leak, LSTM scaler leakage, and horizon_days shadowing. R1-R6 from forecast pipeline audit.