### PR TITLE
fix(forecast): Fix type contract, cascade scoping, and query limit

### DIFF
--- a/supabase/functions/_shared/chart-types.ts
+++ b/supabase/functions/_shared/chart-types.ts
@@ -16,7 +16,7 @@ export interface OHLCBar {
 }
 
 export interface ForecastPoint {
-  ts: number; // Unix ms timestamp
+  ts: number; // Unix seconds timestamp
   value: number;
   lower?: number;
   upper?: number;

--- a/supabase/functions/chart/index.ts
+++ b/supabase/functions/chart/index.ts
@@ -1049,6 +1049,7 @@ serve(async (req: Request): Promise<Response> => {
               .eq("symbol_id", symbolId)
               .in("horizon", [...DAILY_FORECAST_HORIZONS])
               .order("created_at", { ascending: false })
+              .limit(10)
             : Promise.resolve({ data: [], error: null }),
         ]);
 

--- a/supabase/functions/get-multi-horizon-forecasts/index.ts
+++ b/supabase/functions/get-multi-horizon-forecasts/index.ts
@@ -43,6 +43,8 @@ type CascadeForecastRow = {
   handoff_confidence: number | null;
   is_consensus: boolean;
   created_at: string;
+  /** The horizon this cascade row was fetched for (added during collection). */
+  horizon?: string;
 };
 
 type TimeframeGroup = {
@@ -340,7 +342,7 @@ function buildConsensusGroups(
       : [];
 
     const cascade = cascadeRows
-      .filter((c) => c.is_consensus || c.source === row.horizon)
+      .filter((c) => c.horizon === row.horizon)
       .map((c) => ({
         source: c.source,
         direction: c.direction,
@@ -460,16 +462,19 @@ async function loadCascadeRows(
   );
 
   const collected: CascadeForecastRow[] = [];
-  for (const { data, error } of results) {
+  for (let i = 0; i < results.length; i++) {
+    const { data, error } = results[i];
     if (error) {
       return { data: [], error };
     }
 
+    const sourceHorizon = horizons[i];
     const rows = (data ?? []) as CascadeForecastRow[];
     rows.forEach((row) => {
       collected.push({
         ...row,
         source: row.is_consensus ? "consensus" : row.source,
+        horizon: sourceHorizon,
       });
     });
   }


### PR DESCRIPTION
ForecastPoint.ts seconds/ms contract, cascade horizon bleed, ml_forecasts unbounded query. R7-R9 from forecast pipeline audit.