### PR TITLE
feat: Hybrid ML pipeline — Kalman adjustment + weekly training

### DIFF
--- a/.github/workflows/schedule-intraday-forecast.yml
+++ b/.github/workflows/schedule-intraday-forecast.yml
@@ -1,9 +1,8 @@
 # =============================================================================
-# GROUP: 4: Data Ingestion
-# PURPOSE: Generates intraday ML forecasts (15m/1h/4h/8h/1D) during market
-#          hours, evaluates accuracy, and calibrates ensemble layer weights.
-# TRIGGERS: schedule (cron 5,20,35,50 13-22 * * 1-5, offset from ingestion),
-#           workflow_dispatch
+# GROUP: 3: ML Pipeline
+# PURPOSE: Full ensemble training for intraday forecasts (15m/1h/4h/8h/1D).
+#          Between runs, ingest-live's Kalman adjustment keeps forecasts fresh.
+# TRIGGERS: schedule (weekly Monday 4 AM UTC), workflow_dispatch for on-demand
 # COMPONENTS: ml/
 # SECRETS: SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, DATABASE_URL,
 #          ALPACA_API_KEY, ALPACA_API_SECRET
@@ -23,7 +22,7 @@ name: Intraday Forecast
 on:
   # Backup schedule (offset from ingestion to ensure data freshness)
   schedule:
-    - cron: '5,20,35,50 13-22 * * 1-5'  # 5 minutes after each ingestion run
+    - cron: '0 4 * * 1'  # Weekly Monday 4 AM UTC. Kalman adjustment in ingest-live handles real-time updates.
   workflow_dispatch:
     inputs:
       symbol:

--- a/supabase/functions/ingest-live/index.ts
+++ b/supabase/functions/ingest-live/index.ts
@@ -304,10 +304,80 @@ serve(async (req) => {
     }
   }
 
+  // ── Third pass: Kalman forecast adjustment ───────────────────────────────
+  // Adjusts cached intraday forecast target_prices based on actual price
+  // movement since the forecast was generated. Keeps forecasts fresh between
+  // weekly full-ensemble training runs.
+  const KALMAN_GAIN = 0.15; // matches ml/src/intraday_forecast_job.py kalman_weight
+  const ADJUSTMENT_HORIZONS = ["15m", "1h", "4h"];
+  let forecastsAdjusted = 0;
+
+  if (!hitDeadline) {
+    for (const { ticker, symbolId } of symbols) {
+      if (Date.now() - functionStart > DEADLINE_MS) {
+        console.warn("[ingest-live] Deadline during forecast adjustment");
+        hitDeadline = true;
+        break;
+      }
+
+      try {
+        // Get the latest m15 close price for this symbol (just written above)
+        const { data: latestBar } = await supabase
+          .from("ohlc_bars_v2")
+          .select("close")
+          .eq("symbol_id", symbolId)
+          .eq("timeframe", "m15")
+          .eq("is_forecast", false)
+          .order("ts", { ascending: false })
+          .limit(1)
+          .single();
+
+        if (!latestBar?.close) continue;
+        const actualClose = Number(latestBar.close);
+
+        // For each intraday horizon, adjust the latest non-expired forecast
+        for (const horizon of ADJUSTMENT_HORIZONS) {
+          const { data: forecast } = await supabase
+            .from("ml_forecasts_intraday")
+            .select("id, target_price, current_price")
+            .eq("symbol_id", symbolId)
+            .eq("horizon", horizon)
+            .gte("expires_at", new Date().toISOString())
+            .order("created_at", { ascending: false })
+            .limit(1)
+            .single();
+
+          if (!forecast?.target_price || !forecast?.current_price) continue;
+
+          const targetPrice = Number(forecast.target_price);
+          const forecastBasePrice = Number(forecast.current_price);
+
+          // Kalman adjustment: shift target by gain * (actual movement since forecast)
+          const priceMovement = actualClose - forecastBasePrice;
+          const adjustedTarget = targetPrice + KALMAN_GAIN * priceMovement;
+
+          const { error: updateError } = await supabase
+            .from("ml_forecasts_intraday")
+            .update({
+              target_price: adjustedTarget,
+              current_price: actualClose,
+            })
+            .eq("id", forecast.id);
+
+          if (!updateError) forecastsAdjusted++;
+        }
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        console.error(`[ingest-live] Forecast adjust error for ${ticker}:`, msg);
+      }
+    }
+  }
+
   const result = {
     processed: symbols.length,
     totalUpserted,
     m15Upserted,
+    forecastsAdjusted,
     errors: errors.length,
     errorDetails: errors.slice(0, 10),
     errorsTruncated: errors.length > 10,


### PR DESCRIPTION
## Summary

- **Kalman forecast adjustment in ingest-live:** Third pass after m1+m15 ingestion adjusts cached intraday forecasts (15m/1h/4h) based on actual price movement. Gain=0.15 matching existing Python config. Runs every minute via pg_cron.
- **Intraday forecast schedule: every-15-min → weekly:** Full ensemble training now runs Monday 4AM UTC instead of 96x/day. workflow_dispatch preserved for on-demand retraining.

Architecture: "Train weekly, adjust live, evaluate daily"
- Weekly: full LSTM + ARIMA-GARCH ensemble training
- Every minute: Kalman filter adjusts cached forecast targets
- Result: 90%+ reduction in GH Actions ML compute

## Test plan

- [ ] Deploy ingest-live → verify Kalman adjustment pass runs (check logs for forecastsAdjusted count)
- [ ] Query ml_forecasts_intraday → target_price values should shift as market moves
- [ ] Chart endpoint still serves fresh forecasts (no client changes needed)
- [ ] workflow_dispatch on intraday-forecast still works for manual retraining
- [ ] Monitor for 1 week before confirming weekly schedule is sufficient

🤖 Generated with [Claude Code](https://claude.com/claude-code)